### PR TITLE
ManyToMany relations fix

### DIFF
--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -86,9 +86,11 @@ class SoftDeleteListener
                         }
                         elseif($manyToMany) {
 
-                            $mappedSide = get_class($entity) === $namespace;
-                            $inversedSide = ($ns && $entity instanceof $ns);
-                            if ($mappedSide || $inversedSide) {
+                            // For ManyToMany relations, we only delete the relationship between
+                            // two entities. This can be done on both side of the relation.
+                            $allowMappedSide = get_class($entity) === $namespace;
+                            $allowInversedSide = ($ns && $entity instanceof $ns);
+                            if ($allowMappedSide || $allowInversedSide) {
 
                                 if (strtoupper($onDelete->type) === 'SET NULL') {
                                     throw new \Exception('SET NULL is not supported for ManyToMany relationships');

--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -78,7 +78,7 @@ class SoftDeleteListener
                         elseif(class_exists($nsFromRelativeToAbsolute)){
                            $ns = $nsFromRelativeToAbsolute;
                         }
-                        
+
                         if (($manyToOne || $oneToOne) && $ns && $entity instanceof $ns) {
                             $objects = $em->getRepository($namespace)->findBy(array(
                                 $property->name => $entity,
@@ -90,53 +90,10 @@ class SoftDeleteListener
                                 throw new \Exception('SET NULL is not supported for ManyToMany relationships');
                             }
 
-                            $qb = $em->getRepository($namespace)->createQueryBuilder('q')
-                                ->join('q.' . $property->name, 'j');
-
-                            /** @var JoinTable $joinTable */
-                            $joinTable = $reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinTable');
-
-                            if(!$joinTable){
-                                throw new \Exception('No joinTable found for the relationship ' . $namespace. '#'. $property->name);
-                            }
-
-                            $columns = $joinTable->joinColumns;
-                            $inversedColumns = $joinTable->inverseJoinColumns;
-
-                            if (count($columns) > 1) {
-                                throw new \Exception('Only one joinColumn is supported!');
-                            }
-
-                            if (count($inversedColumns) > 1) {
-                                throw new \Exception('Only one inversedJoinColumns is supported!');
-                            }
-
-                            /** @var JoinColumn $joinColumn */
-                            $joinColumn = $columns[0];
-                            $joinProperty = $this->getPropertyByColumName($reflectionClass, $joinColumn);
-
-                            /** @var JoinColumn $joinColumn */
-                            $inversedColumn = $inversedColumns[0];
-                            $inversedJoinProperty = $this->getPropertyByColumName($entityReflection, $inversedColumn);
-
-
-
-                            if (!$joinProperty){
-                                throw new \Exception('No joinColumn found for the relationship between ' .$ns . ' and '. get_class($entity));
-                            }
-
-
-                            if (!$inversedJoinProperty){
-                                throw new \Exception('No joinColumn found for the relationship between ' .$ns . ' and '. get_class($entity));
-                            }
-
                             $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                            $joinValue = $propertyAccessor->getValue($entity, $inversedJoinProperty->name);
-
-                            $qb->where($qb->expr()->eq('j.'.$joinProperty->name,$joinValue ));
-
-                            $objects = $qb->getQuery()->getResult();
-
+                            $collection = $propertyAccessor->getValue($entity, $property->name);
+                            $collection->clear();
+                            continue;
                         }
                     }
 
@@ -176,7 +133,6 @@ class SoftDeleteListener
         }
     }
 
-
     protected function softDeleteCascade($em, $config, $object)
     {
         $meta = $em->getClassMetadata(get_class($object));
@@ -199,20 +155,4 @@ class SoftDeleteListener
             $config['fieldName'] => array($oldValue, $date),
         ));
     }
-
-    private function getPropertyByColumName(\ReflectionClass $entityReflection, $name){
-
-        $reader = new AnnotationReader();
-
-        foreach ($entityReflection->getProperties() as $p) {
-            /** @var $column Column */
-            if (($id = $reader->getPropertyAnnotation($p, Id::class)) &&
-                ($column = $reader->getPropertyAnnotation($p, Column::class)) &&
-                $column->name == $name
-            ) {
-
-               return $p;
-            }
-        }
-     }
 }

--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -86,14 +86,23 @@ class SoftDeleteListener
                         }
                         elseif($manyToMany) {
 
-                            if (strtoupper($onDelete->type) === 'SET NULL') {
-                                throw new \Exception('SET NULL is not supported for ManyToMany relationships');
-                            }
+                            $mappedSide = get_class($entity) === $namespace;
+                            $inversedSide = ($ns && $entity instanceof $ns);
+                            if ($mappedSide || $inversedSide) {
 
-                            $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                            $collection = $propertyAccessor->getValue($entity, $property->name);
-                            $collection->clear();
-                            continue;
+                                if (strtoupper($onDelete->type) === 'SET NULL') {
+                                    throw new \Exception('SET NULL is not supported for ManyToMany relationships');
+                                }
+
+                                try {
+                                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                                    $collection = $propertyAccessor->getValue($entity, $property->name);
+                                    $collection->clear();
+                                    continue;
+                                } catch (\Exception $e) {
+                                    throw new \Exception(sprintf('No accessor found for %s in %s', $property->name, get_class($entity)));
+                                }
+                            }
                         }
                     }
 


### PR DESCRIPTION
For ManyToMany relationship, should it not be enough to empty the collection instead of trying to delete entities ? Here is a proposal, the only mandatory element for this to work is a public accessor in the entity class, as well as the softDeleted annotation.