### PR TITLE
Implement new type called SUCCESSOR

### DIFF
--- a/Mapping/Annotation/onSoftDeleteSuccessor.php
+++ b/Mapping/Annotation/onSoftDeleteSuccessor.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Evence\Bundle\SoftDeleteableExtensionBundle\Mapping\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * onSoftDeleteSuccessor annotation for onSoftDelete behavioral extension.
+ *
+ * @Annotation
+ * @Target("PROPERTY")
+ *
+ * @author Ruben Harms <info@rubenharms.nl>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+final class onSoftDeleteSuccessor extends Annotation
+{
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ To (soft-)delete an entity when its parent record is soft-deleted :
  @Evence\onSoftDelete(type="SET NULL")
 ```
 
+**Replace reference by some property marked as successor (must be of same entity class)**
+
+```
+ @Evence\onSoftDelete(type="SUCCESSOR")
+```
+
 ## Entity example
 
 ``` php


### PR DESCRIPTION
Depending on your use case you might want to define some successor who takes over all relations that were owned by the entity that is going to be deleted.

Implementation assumes that the entity to be delelted should hold the information about its successor.

With type SUCCESSOR and by adding annotation onSoftDeleteSuccessor to one of the properties of soft deleted entity, all relations are replaced to point to the new entity instead.

**How we use it in our project:**
When a user decides to delete User entity we bring up a modal and ask to define a successor (another User). We update the entity and set the successor and right after we delete the entity. OnSoftDelete will then replace all relations to the user with the successor.

**What else:**
We moved out the processing of types to protected methods to make it easier for someone to override the Listener with some custom funtionality while keeping the hard part that is implemented in Listener.

I would be happy if this is not considered a edge case and might be merged.

Cheers Ben