### PR TITLE
Fix mtm inversed

### DIFF
--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -105,15 +105,19 @@ class SoftDeleteListener
                                 $mtmRelations = $em->getRepository($namespace)->createQueryBuilder('entity')
                                     ->innerJoin(sprintf('entity.%s', $property->name), 'mtm')
                                     ->addSelect('mtm')
-                                    ->andWhere(sprintf(':entity MEMBER entity.%s', $property->name))
+                                    ->andWhere(sprintf(':entity MEMBER OF entity.%s', $property->name))
                                     ->setParameter('entity', $entity)
                                     ->getQuery()
                                     ->getResult();
 
                                 foreach ($mtmRelations as $mtmRelation) {
-                                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                                    $collection = $propertyAccessor->getValue($mtmRelation, $property->name);
-                                    $collection->removeElement($entity);
+                                    try {
+                                        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                                        $collection = $propertyAccessor->getValue($mtmRelation, $property->name);
+                                        $collection->removeElement($entity);
+                                    } catch (\Exception $e) {
+                                        throw new \Exception(sprintf('No accessor found for %s in %s', $property->name, get_class($mtmRelation)));
+                                    }
                                 }
                             } elseif ($allowMappedSide) {
                                 try {

--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -101,7 +101,21 @@ class SoftDeleteListener
                             // two entities. This can be done on both side of the relation.
                             $allowMappedSide = get_class($entity) === $namespace;
                             $allowInversedSide = ($ns && $entity instanceof $ns);
-                            if ($allowMappedSide || $allowInversedSide) {
+                            if ($allowInversedSide) {
+                                $mtmRelations = $em->getRepository($namespace)->createQueryBuilder('entity')
+                                    ->innerJoin(sprintf('entity.%s', $property->name), 'mtm')
+                                    ->addSelect('mtm')
+                                    ->andWhere(sprintf(':entity MEMBER entity.%s', $property->name))
+                                    ->setParameter('entity', $entity)
+                                    ->getQuery()
+                                    ->getResult();
+
+                                foreach ($mtmRelations as $mtmRelation) {
+                                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                                    $collection = $propertyAccessor->getValue($mtmRelation, $property->name);
+                                    $collection->removeElement($entity);
+                                }
+                            } elseif ($allowMappedSide) {
                                 try {
                                     $propertyAccessor = PropertyAccess::createPropertyAccessor();
                                     $collection = $propertyAccessor->getValue($entity, $property->name);


### PR DESCRIPTION
[fix this issue](https://github.com/E-vence/SoftDeleteableListenerExtensionBundle/issues/6)

i try create mtm relation like this:

Article.php
```
    /**
     * @ORM\ManyToMany(targetEntity="Place")
     * @ORM\JoinTable(
     *     joinColumns={@ORM\JoinColumn(onDelete="CASCADE", nullable=false, name="article_id", referencedColumnName="id")},
     *     inverseJoinColumns={@ORM\JoinColumn(onDelete="CASCADE", nullable=false, name="place_id", referencedColumnName="id")}
     * )
     * @onSoftDelete(type="CASCADE")
     */
    private $places;
```

and i get error when delete Place likned to Article:
`No accessor found for places in Place`

but in Place no inversed side relation!

i write this fix, and him worked two delete scenario:
1) if delete Place - relations deleted by fixed code with getting mtm related collections and removeElement 
2) if delete Article - relations deleted with old code via $collection->clear()