### PR TITLE
Trigger events on cascade

### DIFF
--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -18,6 +18,7 @@ use Evence\Bundle\SoftDeleteableExtensionBundle\Exception\OnSoftDeleteUnknownTyp
 use Evence\Bundle\SoftDeleteableExtensionBundle\Mapping\Annotation\onSoftDelete;
 use Evence\Bundle\SoftDeleteableExtensionBundle\Mapping\Annotation\onSoftDeleteSuccessor;
 use Gedmo\Mapping\ExtensionMetadataFactory;
+use Gedmo\SoftDeleteable\SoftDeleteableListener as GedmoSoftDeleteableListener;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -306,7 +307,11 @@ class SoftDeleteListener
 
         //check next level
         $args = new LifecycleEventArgs($object, $em);
-        $this->preSoftDelete($args);
+        $em->getEventManager()->dispatchEvent(
+            GedmoSoftDeleteableListener::PRE_SOFT_DELETE,
+            $args
+        );
+        //$this->preSoftDelete($args);
 
         $date = new \DateTime();
         $reflProp->setValue($object, $date);
@@ -316,6 +321,11 @@ class SoftDeleteListener
         $uow->scheduleExtraUpdate($object, array(
             $config['fieldName'] => array($oldValue, $date),
         ));
+
+        $em->getEventManager()->dispatchEvent(
+            GedmoSoftDeleteableListener::POST_SOFT_DELETE,
+            new LifecycleEventArgs($object, $em)
+        );
     }
 
     /**

--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -305,13 +305,11 @@ class SoftDeleteListener
             return;
         }
 
-        //check next level
-        $args = new LifecycleEventArgs($object, $em);
+        //trigger event to check next level
         $em->getEventManager()->dispatchEvent(
             GedmoSoftDeleteableListener::PRE_SOFT_DELETE,
-            $args
+            LifecycleEventArgs($object, $em)
         );
-        //$this->preSoftDelete($args);
 
         $date = new \DateTime();
         $reflProp->setValue($object, $date);


### PR DESCRIPTION
The events `preSoftDelete` and `postSoftDelete` were not triggered by this extension, although it performs softDeletes.

This behaviour is fixed by this pull-request.