### PR TITLE
PHP 8 constraints added for PHP Atributtes usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }],
     "keywords": ["soft-deleteable"],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.0",
         "symfony/framework-bundle": "^5.0 || ^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Changes to require minim version of php 8.0 to be used for PHP ATTRIBUTES