### PR TITLE
Fixes wrong type expectation in onSoftDelete constructor

### DIFF
--- a/Mapping/Annotation/onSoftDelete.php
+++ b/Mapping/Annotation/onSoftDelete.php
@@ -19,10 +19,4 @@ final class onSoftDelete // extends Annotation
 {
     /** @var string @Required */
     public $type;
-
-    public function __construct(
-        ?string $type = null
-    ) {
-        $this->type = $type;
-    }
 }


### PR DESCRIPTION
softDelete constructor was changed to accept `?string $type` but it's in fact an array `['type' => 'CASCADE']`.

Fixes #38