### PR TITLE
Remove deprecated (and unused) containerAwareTrait in EventListener\SoftDeleteListener

### DIFF
--- a/EventListener/SoftDeleteListener.php
+++ b/EventListener/SoftDeleteListener.php
@@ -20,7 +20,6 @@ use Evence\Bundle\SoftDeleteableExtensionBundle\Mapping\Annotation\onSoftDelete;
 use Evence\Bundle\SoftDeleteableExtensionBundle\Mapping\Annotation\onSoftDeleteSuccessor;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\SoftDeleteable\SoftDeleteableListener as GedmoSoftDeleteableListener;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -33,8 +32,6 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class SoftDeleteListener
 {
-    use ContainerAwareTrait;
-
     /**
      * @var Reader
      */

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -6,9 +6,6 @@ use Symfony\Component\DependencyInjection\Reference;
 /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
 $container->setDefinition('evence.softdeletale.listener.softdelete', new Definition('Evence\Bundle\SoftDeleteableExtensionBundle\EventListener\SoftDeleteListener', array(new Reference('annotation_reader'))))
 
-->addMethodCall('setContainer', array(
-    new Reference('service_container'),
-))
 ->addTag('doctrine.event_listener', array(
     'event' => 'preSoftDelete',
 ));


### PR DESCRIPTION
Hi.
File `EventListener/SoftDeleteListener.php` uses `ContainerAwareTrait` but `$this->container` is never used. Besides, Symfony throws a warning because `ContainerAwareTrait` is deprecated and we should use dependency injection instead.

Removing the trait kills two birds with one stone.

Thanks for reviewing.